### PR TITLE
Enforce SSL usage in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'coffee-rails', '~> 4.0.0'
 gem 'therubyracer'
 gem 'haml-rails'
 gem 'redcarpet'
+gem 'rack-ssl-enforcer'
 
 gem 'jquery-rails'
 gem 'turbolinks'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,7 @@ GEM
     puma (2.11.3)
       rack (>= 1.1, < 2.0)
     rack (1.5.2)
+    rack-ssl-enforcer (0.2.8)
     rack-test (0.6.2)
       rack (>= 1.0)
     rack-timeout (0.2.4)
@@ -273,6 +274,7 @@ DEPENDENCIES
   pg
   pluggable_js
   puma
+  rack-ssl-enforcer
   rack-timeout
   rails (= 4.1.1)
   rails-assets-Hover

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,9 @@ Bundler.require(*Rails.groups)
 
 module Hackedu
   class Application < Rails::Application
+    # Redirect HTTP to HTTPS in production
+    config.middleware.use Rack::SslEnforcer, only_environments: 'production'
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
This pull request adds `rack-ssl-enforcer`, which is set up to redirect all HTTP traffic to HTTPS in production.

In the past we did this on the reverse proxy level (with Nginx), but now that we're using Empire (https://github.com/remind101/empire) we have to do it on the application layer because we don't have direct control over the reverse proxy.