### PR TITLE
Delete .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: ruby
-rvm:
-  - 2.1.2
-  - 2.1.1
-  - 2.1.0
-env:
-  - SECRET_KEY_BASE=ASECRETKEY
-cache: bundler


### PR DESCRIPTION
We've switched our CI from Travis to CircleCI, so `.travis.yml` is no longer needed.