### PR TITLE
Allow CircleCI to collect test metadata.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :development, :test do
   gem 'capybara'
   gem 'faker'
   gem 'email_spec'
+  gem 'rspec_junit_formatter'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,9 @@ GEM
       rspec-mocks (~> 3.1.0)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
+    rspec_junit_formatter (0.2.3)
+      builder (< 4)
+      rspec-core (>= 2, < 4, != 2.12.0)
     ruby_parser (3.1.3)
       sexp_processor (~> 4.1)
     sass (3.2.19)
@@ -281,6 +284,7 @@ DEPENDENCIES
   rails-assets-underscore
   redcarpet
   rspec-rails
+  rspec_junit_formatter
   sass-rails (~> 4.0.3)
   sdoc (~> 0.4.0)
   shoulda


### PR DESCRIPTION
This change installs `rspec_junit_formatter`, which allows CircleCI to collect test metadata and better show test results.

See https://circleci.com/docs/test-metadata#automatic-test-metadata-collection for more details.