### PR TITLE
Block referrer spam.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'therubyracer'
 gem 'haml-rails'
 gem 'redcarpet'
 gem 'rack-ssl-enforcer'
+gem 'rack-attack'
 
 gem 'jquery-rails'
 gem 'turbolinks'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,8 @@ GEM
     puma (2.11.3)
       rack (>= 1.1, < 2.0)
     rack (1.5.2)
+    rack-attack (4.3.0)
+      rack
     rack-ssl-enforcer (0.2.8)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -277,6 +279,7 @@ DEPENDENCIES
   pg
   pluggable_js
   puma
+  rack-attack
   rack-ssl-enforcer
   rack-timeout
   rails (= 4.1.1)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ The following secrets are also required for production.
 * `SMTP_PASSWORD`
 * `SMTP_DOMAIN`
 
+#### Optional Variables
+
+* `REFERRERS_TO_BLOCK`
+  * A list of regular expressions of hostnames to block, separated by `|`. This
+    is used to prevent
+    [referrer spam](https://en.wikipedia.org/wiki/Referer_spam)
+    * Examples: `.*\.spam\.com|\w+.spamwow.\w+`, `bad\.referrer\.com`
+
 ### Start server
 
     $ rails serve

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ module Hackedu
     # Redirect HTTP to HTTPS in production
     config.middleware.use Rack::SslEnforcer, only_environments: 'production'
 
+    # Block referer spam
+    config.middleware.use Rack::Attack
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,8 @@
+class Rack::Attack
+  spammer_string = (Figaro.env.REFERRERS_TO_BLOCK || '')
+  spammers = spammer_string.split('|').map { |spammer| Regexp.new(spammer) }
+
+  blacklist('block referral spam') do |request|
+    spammers.find { |spammer| request.referer =~ spammer }
+  end
+end


### PR DESCRIPTION
Right now we have some... interesting individuals spamming our analytics with referrals.

From our analytics:

![tmp](https://cloud.githubusercontent.com/assets/992248/9532740/4ca7a962-4cc2-11e5-9a95-b7635a582909.png)

This change installs rack-attack and configures it to block referrer spam from the `REFERRERS_TO_BLOCK` environment variable to block them.

@MaxWofford can you review/merge this when you have the chance?