### PR TITLE
Fix off-canvas menu with Turbolinks and on mobile

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,4 +18,6 @@
 //= require gmaps/google
 //= require_tree .
 
-$(function(){ $(document).foundation(); });
+window.onload = function() {
+  $(document).foundation();
+};

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -23,7 +23,7 @@
             %ul.right= render 'layouts/nav'
         %nav.tab-bar.show-for-small
           %section.left-small
-            %a.left-off-canvas-toggle.menu-icon
+            %a.left-off-canvas-toggle.menu-icon{href: '#'}
               %span
           %section.middle.tab-bar-section
             %h1.title <span class="hackedu-logo">hackEDU</span>


### PR DESCRIPTION
This PR fixes Foundation's off-canvas menu when used with Turbolinks and on mobile devices.